### PR TITLE
Allow caller to pass in AWS client configuration

### DIFF
--- a/src/helpers/eventBridge.ts
+++ b/src/helpers/eventBridge.ts
@@ -1,5 +1,10 @@
 /* eslint-disable max-lines */
-import { AWSError, EventBridge as AWSEventBridge, SQS } from "aws-sdk";
+import {
+  ConfigurationOptions as AWSConfig,
+  AWSError,
+  EventBridge as AWSEventBridge,
+  SQS,
+} from "aws-sdk";
 import { PromiseResult } from "aws-sdk/lib/request";
 import { AWSClient, region } from "./general";
 import { removeUndefinedMessages } from "./utils/removeUndefinedMessages";
@@ -13,15 +18,18 @@ export default class EventBridge {
   sqsClient: SQS | undefined;
   targetId: string | undefined;
 
-  async init(eventBridgeName: string): Promise<void> {
-    this.eventBridgeClient = new AWSClient.EventBridge();
+  async init(
+    eventBridgeName: string,
+    awsClientConfig?: AWSConfig
+  ): Promise<void> {
+    this.eventBridgeClient = new AWSClient.EventBridge(awsClientConfig);
     this.eventBridgeName = eventBridgeName;
     this.ruleName = `test-${eventBridgeName}-rule`;
     this.targetId = "1";
 
     const keepArg = process.argv.filter((x) => x.startsWith("--keep="))[0];
     this.keep = keepArg ? keepArg.split("=")[1] === "true" : false;
-    this.sqsClient = new AWSClient.SQS();
+    this.sqsClient = new AWSClient.SQS(awsClientConfig);
     if (!this.keep) {
       console.info(
         "If running repeatedly add '--keep=true' to keep testing resources up to avoid creation throttles"
@@ -91,9 +99,12 @@ export default class EventBridge {
       .promise();
   }
 
-  static async build(eventBridgeName: string): Promise<EventBridge> {
+  static async build(
+    eventBridgeName: string,
+    awsClientConfig?: AWSConfig
+  ): Promise<EventBridge> {
     const eventBridge = new EventBridge();
-    await eventBridge.init(eventBridgeName);
+    await eventBridge.init(eventBridgeName, awsClientConfig);
 
     return eventBridge;
   }

--- a/src/helpers/stepFunctions.ts
+++ b/src/helpers/stepFunctions.ts
@@ -1,19 +1,22 @@
-import { StepFunctions as AWSStepFunctions } from "aws-sdk";
+import {
+  ConfigurationOptions as AWSConfig,
+  StepFunctions as AWSStepFunctions,
+} from "aws-sdk";
 
 export default class StepFunctions {
   stepFunctions: AWSStepFunctions | undefined;
   allStateMachines: AWSStepFunctions.ListStateMachinesOutput | undefined;
 
-  async init(): Promise<void> {
-    this.stepFunctions = new AWSStepFunctions();
+  async init(awsClientConfig?: AWSConfig): Promise<void> {
+    this.stepFunctions = new AWSStepFunctions(awsClientConfig);
     this.allStateMachines = await this.stepFunctions
       .listStateMachines()
       .promise();
   }
 
-  static async build(): Promise<StepFunctions> {
+  static async build(awsClientConfig?: AWSConfig): Promise<StepFunctions> {
     const stepFunction = new StepFunctions();
-    await stepFunction.init();
+    await stepFunction.init(awsClientConfig);
 
     return stepFunction;
   }


### PR DESCRIPTION
This PR adds an optional second parameter to the `EventBridge.build` and `StepFunctions.build` methods, which allows the caller to specify AWS service client configuration. This permits a user to override the default hostname, timeout, specify a logger, etc. 

The behaviour when no client config is specified is the same as the current behaviour.

Closes #31 

Usage example:

```ts
import { EventBridge } from 'sls-test-tools'

const awsConfig = { endpoint: 'http://localhost:4566', region: 'eu-west-1' } // override the default endpoint so that it can be used against localstack
const localBus = await EventBridge.build('my-local-bus', awsConfig)
const awsBus = await EventBridge.build('aws-bus') // same as current behaviour
```

The use case for myself is to allow overriding the endpoint as shown above so tests can run against localstack. This will also open up the possibility of writing tests for the library itself using localstack if desired. 
