### PR TITLE
Externalize Event Bridge Rule and SQS Queue Name

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,8 @@ An interface to a deployed Step Function, with a function to execute a Step Func
 - `'--profile=[PROFILE NAME]'` or `process.env.AWS_PROFILE` (will default to `default`)
 - `'--region=[AWS Region]'` or `process.env.AWS_REGION` (will default to `eu-west-2`)
 - `'--keep=true'` - keeps testing resources up to avoid creation throttles (e.g. SQS Queue created for EventBridge assertions)
+- `'--event-rule-name=[Event Bus Rule Name]'` - Custom Event bridge Rule name (will deafult to `test-${eventBridgeName}-rule`)
+- `'--queue-name=[SQS Queue Name]'` - Custom SQS Queue name (will deafult to `${eventBridgeName}-testing-queue`)
 
 - To avoid issues we recommend `--runInBand`
 

--- a/src/helpers/eventBridge.ts
+++ b/src/helpers/eventBridge.ts
@@ -21,13 +21,18 @@ export default class EventBridge {
 
     const keepArg = process.argv.filter((x) => x.startsWith("--keep="))[0];
     this.keep = keepArg ? keepArg.split("=")[1] === "true" : false;
+    const ruleNameArg = process.argv.filter((x) => x.startsWith("--event-rule-name="))[0];
+    this.ruleName = ruleNameArg ? ruleNameArg.split("=")[1] : `test-${eventBridgeName}-rule`;
+    const queueNameArg = process.argv.filter((x) => x.startsWith("--queue-name="))[0];
+    const queueName = queueNameArg ? queueNameArg.split("=")[1] : `${eventBridgeName}-testing-queue`;
+    
     this.sqsClient = new AWSClient.SQS();
     if (!this.keep) {
       console.info(
         "If running repeatedly add '--keep=true' to keep testing resources up to avoid creation throttles"
       );
     }
-    const queueName = `${eventBridgeName}-testing-queue`;
+  
     const queueResult = await this.sqsClient
       .createQueue({
         QueueName: queueName,

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,7 @@ declare global {
       toHaveEvent(): R;
       toHaveEventWithSource(expectedSourceName: string): R;
       toHaveS3ObjectWithNameEqualTo(objectName: string): Promise<R>;
+      toContainItemWithValues(values:{ [key: string]: unknown }): Promise<R>;
     }
   }
 }


### PR DESCRIPTION
We have certain IAM policy that the event rule name and queue name must be having the "Application Name" as prefix.
eg: appname-* . Hence added the code to externalize the event rule name and SQS Queue name. 

Have added 2 optional CLI parameters **_(--event-rule-name, --queue-name)_** to pass the custom event rule name and SQS queue name
 