### PR TITLE
Expose 'keep=true' as environment variable in addition to CLI arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ An interface to a deployed Step Function, with a function to execute a Step Func
 
 - `'--profile=[PROFILE NAME]'` or `process.env.AWS_PROFILE` (will default to `default`)
 - `'--region=[AWS Region]'` or `process.env.AWS_REGION` (will default to `eu-west-2`)
-- `'--keep=true'` - keeps testing resources up to avoid creation throttles (e.g. SQS Queue created for EventBridge assertions)
+- `'--keep=true'` or `process.env.SLS_TEST_TOOLS_KEEP` (will default to `false`) - keeps testing resources up to avoid creation throttles (e.g. SQS Queue created for EventBridge assertions)
 
 - To avoid issues we recommend `--runInBand`
 

--- a/src/helpers/eventBridge.ts
+++ b/src/helpers/eventBridge.ts
@@ -20,7 +20,9 @@ export default class EventBridge {
     this.targetId = "1";
 
     const keepArg = process.argv.filter((x) => x.startsWith("--keep="))[0];
-    this.keep = keepArg ? keepArg.split("=")[1] === "true" : false;
+    const keepArgEnabled = keepArg ? keepArg.split("=")[1] === "true" : false;
+    const keepEnvVarEnabled = !!process.env.SLS_TEST_TOOLS_KEEP;
+    this.keep = keepArgEnabled || keepEnvVarEnabled;
     this.sqsClient = new AWSClient.SQS();
     if (!this.keep) {
       console.info(


### PR DESCRIPTION
In fab9ab0e0039bfa1944db328c31e98b615a7f3e3, some (but not all) of the CLI arguments were also made accessible as environment variables. This PR extends that availability to the `--keep=true` CLI argument, which previously could not be set using environment variables.

This helps in situations where CLI arguments are unable to be passed through to the test runner.