### PR TITLE
add delay when polling the API in stepfunctions helper

### DIFF
--- a/src/helpers/stepFunctions.ts
+++ b/src/helpers/stepFunctions.ts
@@ -1,6 +1,8 @@
 import { StepFunctions as AWSStepFunctions } from "aws-sdk";
 import { AWSClient } from "./general";
 
+const API_POLLING_DELAY_MS = 1000;
+
 export default class StepFunctions {
   stepFunctions: AWSStepFunctions | undefined;
   allStateMachines: AWSStepFunctions.ListStateMachinesOutput | undefined;
@@ -59,6 +61,9 @@ export default class StepFunctions {
       executionList = await this.stepFunctions
         .listExecutions(listExecParams)
         .promise();
+
+      // Wait before retrying to avoid throttle limits
+      await new Promise((resolve) => setTimeout(resolve, API_POLLING_DELAY_MS));
     }
 
     return await this.stepFunctions


### PR DESCRIPTION
After ~70 seconds waiting for a step function to finish its execution, we receive a `ThrottlingException: Rate exceeded`

This PR adds a 1 second delay between API calls to avoid this. An improvement could be having this delay as a user setting, but it seemed a bit overkill to me, let me know if I should add it :)

According to https://docs.aws.amazon.com/step-functions/latest/dg/limits-overview.html
The API as a bucket/refill of 200/5 for main AWS regions, and 100/2 for other regions.
A 1 second delay should be more than enough to avoid this Quota :)